### PR TITLE
Build both 32-bit and 64-bit versions

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,6 +3,6 @@ from conan.packager import ConanMultiPackager
 
 if __name__ == "__main__":
     builder = ConanMultiPackager()
-    builder.add({"os": "Windows", "arch": "x86_64"}, {}, {}, {})
-    builder.add({"os": "Windows", "arch": "x86"}, {}, {}, {})
+    builder.add({"os_build": "Windows", "arch_build": "x86_64"}, {}, {}, {})
+    builder.add({"os_build": "Windows", "arch_build": "x86"}, {}, {}, {})
     builder.run()


### PR DESCRIPTION
on conan 1.x strawberryperl uses os_build/arch_build, not os/arch.

only x86_64 got built after #4 was merged.

```
    Package_ID: 456f15897172eef340fcbac8a70811f2beb26a93
        [settings]
            arch_build: x86_64
            os_build: Windows
        Outdated from recipe: False
```